### PR TITLE
Enum consistency

### DIFF
--- a/src/database/DB.java
+++ b/src/database/DB.java
@@ -1,10 +1,6 @@
 package database;
 
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
+import java.sql.*;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -243,20 +239,18 @@ public class DB {
 		Connection conn = init();
 
 		try {
-
 			Statement s = conn.createStatement();
 			ResultSet rs = s.executeQuery(
 					String.format("SELECT * FROM item WHERE name='%s' AND container='%s'", itemName, c.getName()));
 
 			if (rs.next()) {
 				System.out.println(itemName);
-				GenericTag<FoodGroup> fg = GenericTag.fromString(FoodGroup.class, rs.getString("fg"));
-				GenericTag<FoodFreshness> fresh = GenericTag.fromString(FoodFreshness.class, rs.getString("fresh"));
+				GenericTag<FoodGroup> fg = (rs.getString("fg") != null) ? GenericTag.fromString(FoodGroup.class, rs.getString("fg")) : null;
+				GenericTag<FoodFreshness> fresh = (rs.getString("fresh") != null) ? GenericTag.fromString(FoodFreshness.class, rs.getString("fresh")) : null;
 
 				conn.close();
 				return Item.getInstance(rs.getString("name"), fg, fresh, rs.getInt("quantity"), rs.getDate("expiry"));
 			}
-			// Return null if the Container or Item is not found.
 		} catch (SQLException e) {
 			e.printStackTrace();
 		}
@@ -264,6 +258,35 @@ public class DB {
 		return null;
 
 	}
+
+	public void updateItem(Container c, String itemName, FoodGroup newFoodGroup, FoodFreshness newFreshness) {
+		List<String> setClauses = new ArrayList<>();
+		if (newFoodGroup != null) {
+			setClauses.add("fg = '" + newFoodGroup.getDisplayName() + "'");
+		}
+		if (newFreshness != null) {
+			setClauses.add("fresh = '" + newFreshness.getDisplayName() + "'");
+		}
+
+		if (setClauses.isEmpty()) {
+			// If there are no updates to make, simply return
+			return;
+		}
+
+		String setClause = String.join(", ", setClauses);
+		String sql = "UPDATE item SET " + setClause + " WHERE name = ? AND container = ?";
+
+		try (Connection conn = this.init();
+			 PreparedStatement pstmt = conn.prepareStatement(sql)) {
+			pstmt.setString(1, itemName);
+			pstmt.setString(2, c.getName());
+			pstmt.executeUpdate();
+		} catch (SQLException e) {
+			e.printStackTrace();
+		}
+	}
+
+
 
 	/**
 	 * Returns a list of Items belonging to a Container in the database

--- a/src/database/DB.java
+++ b/src/database/DB.java
@@ -8,10 +8,9 @@ import java.sql.Statement;
 import java.util.ArrayList;
 import java.util.List;
 
-import domain.logic.Container;
-import domain.logic.FoodFreshness;
-import domain.logic.FoodGroup;
-import domain.logic.Item;
+import domain.logic.*;
+
+import static domain.logic.GenericTag.fromString;
 
 /**
  * The {@code DB} class represents a simple database for storing and managing
@@ -251,11 +250,11 @@ public class DB {
 
 			if (rs.next()) {
 				System.out.println(itemName);
-				FoodGroup fg = FoodGroup.valueOf(rs.getString("fg"));
-				FoodFreshness fresh = FoodFreshness.valueOf(rs.getString("fresh"));
+				GenericTag<FoodGroup> fg = GenericTag.fromString(FoodGroup.class, rs.getString("fg"));
+				GenericTag<FoodFreshness> fresh = GenericTag.fromString(FoodFreshness.class, rs.getString("fresh"));
 
 				conn.close();
-				return Item.getInstance(rs.getString("name"), rs.getInt("quantity"), rs.getDate("expiry"));
+				return Item.getInstance(rs.getString("name"), fg, fresh, rs.getInt("quantity"), rs.getDate("expiry"));
 			}
 			// Return null if the Container or Item is not found.
 		} catch (SQLException e) {

--- a/src/database/DB.java
+++ b/src/database/DB.java
@@ -9,6 +9,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 import domain.logic.Container;
+import domain.logic.FoodFreshness;
+import domain.logic.FoodGroup;
 import domain.logic.Item;
 
 /**
@@ -249,6 +251,9 @@ public class DB {
 
 			if (rs.next()) {
 				System.out.println(itemName);
+				FoodGroup fg = FoodGroup.valueOf(rs.getString("fg"));
+				FoodFreshness fresh = FoodFreshness.valueOf(rs.getString("fresh"));
+
 				conn.close();
 				return Item.getInstance(rs.getString("name"), rs.getInt("quantity"), rs.getDate("expiry"));
 			}

--- a/src/database/DB.java
+++ b/src/database/DB.java
@@ -286,8 +286,6 @@ public class DB {
 		}
 	}
 
-
-
 	/**
 	 * Returns a list of Items belonging to a Container in the database
 	 * 

--- a/src/domain/logic/FoodFreshness.java
+++ b/src/domain/logic/FoodFreshness.java
@@ -7,17 +7,17 @@ public enum FoodFreshness implements Tag {
     /**
      * Indicates that the food item has expired.
      */
-    EXPIRED("expired"),
+    EXPIRED("Expired"),
 
     /**
      * Indicates that the food item is fresh.
      */
-    FRESH("fresh"),
+    FRESH("Fresh"),
 
     /**
      * Indicates that the food item is nearing its expiry date.
      */
-    NEAR_EXPIRY("near expiry");
+    NEAR_EXPIRY("Near_Expiry");
 
     private final String displayName;
 

--- a/src/domain/logic/FoodGroup.java
+++ b/src/domain/logic/FoodGroup.java
@@ -7,27 +7,27 @@ public enum FoodGroup implements Tag {
     /**
      * Represents grains food group.
      */
-    GRAIN("grain"),
+    GRAIN("Grain"),
 
     /**
      * Represents protein food group.
      */
-    PROTEIN("protein"),
+    PROTEIN("Protein"),
 
     /**
      * Represents vegetable food group.
      */
-    VEGETABLE("vegetable"),
+    VEGETABLE("Vegetable"),
 
     /**
      * Represents fruit food group.
      */
-    FRUIT("fruit"),
+    FRUIT("Fruit"),
 
     /**
      * Represents dairy food group.
      */
-    DAIRY("dairy");
+    DAIRY("Dairy");
 
     private final String displayName;
 

--- a/src/domain/logic/FoodGroup.java
+++ b/src/domain/logic/FoodGroup.java
@@ -49,4 +49,13 @@ public enum FoodGroup implements Tag {
     public String getDisplayName() {
         return displayName;
     }
+
+    public static FoodGroup fromDisplayName(String displayName) {
+        for (FoodGroup group : values()) {
+            if (group.getDisplayName().equals(displayName)) {
+                return group;
+            }
+        }
+        throw new IllegalArgumentException("DisplayName not found: " + displayName);
+    }
 }

--- a/src/domain/logic/FoodGroup.java
+++ b/src/domain/logic/FoodGroup.java
@@ -49,13 +49,4 @@ public enum FoodGroup implements Tag {
     public String getDisplayName() {
         return displayName;
     }
-
-    public static FoodGroup fromDisplayName(String displayName) {
-        for (FoodGroup group : values()) {
-            if (group.getDisplayName().equals(displayName)) {
-                return group;
-            }
-        }
-        throw new IllegalArgumentException("DisplayName not found: " + displayName);
-    }
 }

--- a/src/domain/logic/Item.java
+++ b/src/domain/logic/Item.java
@@ -14,7 +14,7 @@ import java.util.Locale;
  */
 public class Item implements Comparable<Item>{
     private String name;
-    private Set<GenericTag<FoodGroup>> foodGroupTags = new HashSet<>();
+    private GenericTag<FoodGroup> foodGroupTag;
     private GenericTag<FoodFreshness> foodFreshnessTag;
     private int quantity;
 
@@ -187,43 +187,37 @@ public class Item implements Comparable<Item>{
     }
 
     /**
-     * Gets a deep copy of the set of food group tags.
+     * Gets the food freshness tag.
      *
-     * @return A copy of the set of food group tags.
+     * @return The food freshness tag if it exists, or null otherwise.
      */
-    public Set<GenericTag<FoodGroup>> getFoodGroupTags() {
-        Set<GenericTag<FoodGroup>> temp = new HashSet<>();
-        for(GenericTag<FoodGroup> tag: this.foodGroupTags){
-            temp.add(new GenericTag<>(tag.getTag()));
+    public GenericTag<FoodGroup> getFoodGroupTag() {
+        // Directly return null if foodFreshnessTag is null, avoiding NullPointerException
+        if (this.foodGroupTag == null) {
+            return null;
         }
-        return temp;
+        // Otherwise, return a new GenericTag with the existing tag value
+        return new GenericTag<>(this.foodGroupTag.getTag());
     }
 
     /**
-     * Sets the food group tags from a set of GenericTag<FoodGroup>.
+     * Sets the food freshness tag from a GenericTag<FoodFreshness>.
      *
-     * @param foodGroupTags The new set of food group tags.
+     * @param tag The new food freshness tag.
      */
-    public void setFoodGroupTags(Set<GenericTag<FoodGroup>> foodGroupTags) {
-        this.foodGroupTags.clear();
-        for(GenericTag<FoodGroup> tag: foodGroupTags){
-            this.foodGroupTags.addAll(foodGroupTags);
-        }
+    public void setFoodGroupTag(GenericTag<FoodGroup> tag) {
+        this.foodGroupTag = new GenericTag<>(tag);
     }
 
     /**
-     * Sets the food group tags directly from a set of FoodGroup enums.
+     * Sets the food freshness tag directly from a FoodFreshness enum.
      *
-     * @param foodGroupTags The set of FoodGroup enums.
+     * @param tag The FoodFreshness enum value.
      */
-    public void setFoodGroupTagsEnum(Set<FoodGroup> foodGroupTags) {
-        this.foodGroupTags.clear();
-        if(foodGroupTags != null){
-            for(FoodGroup tag: foodGroupTags){
-                this.foodGroupTags.add(new GenericTag<>(tag));
-            }
-        }
+    public void setFoodFreshnessTag(FoodFreshness tag) {
+        this.foodFreshnessTag = new GenericTag<>(tag);
     }
+
 
     /**
      * Gets the food freshness tag.

--- a/src/domain/logic/Item.java
+++ b/src/domain/logic/Item.java
@@ -37,15 +37,15 @@ public class Item implements Comparable<Item>{
      * Factory method to create an instance of Item with specified properties.
      *
      * @param name The name of the item.
-     * @param foodGroupTags A set of generic tags representing the food groups of the item.
+     * @param foodGroupTag A set of generic tags representing the food groups of the item.
      * @param foodFreshnessTag A generic tag representing the freshness of the item.
      * @param quantity The quantity of the item.
      * @param expiryDate The expiration date of the item.
      * @return An instance of Item.
      */
-    public static Item getInstance(String name, Set<GenericTag<FoodGroup>> foodGroupTags, GenericTag<FoodFreshness> foodFreshnessTag, int quantity, Date expiryDate){
+    public static Item getInstance(String name, GenericTag<FoodGroup> foodGroupTag, GenericTag<FoodFreshness> foodFreshnessTag, int quantity, Date expiryDate){
         Item item = Item.getInstance(name, quantity, expiryDate);
-        item.setFoodGroupTags(foodGroupTags);
+        item.setFoodGroupTag(foodGroupTag);
         item.setFoodFreshnessTag(foodFreshnessTag);
         return item;
     }
@@ -54,30 +54,30 @@ public class Item implements Comparable<Item>{
      * Factory method to create an instance of Item with specified properties including a string representation of the expiry date.
      *
      * @param name The name of the item.
-     * @param foodGroupTags A set of generic tags representing the food groups of the item.
+     * @param foodGroupTag A set of generic tags representing the food groups of the item.
      * @param foodFreshnessTag A generic tag representing the freshness of the item.
      * @param quantity The quantity of the item.
      * @param expiryDate A string representation of the expiration date in the format "dd-MMMM-yyyy".
      * @return An instance of Item.
      */
-    public static Item getInstance(String name, Set<GenericTag<FoodGroup>> foodGroupTags, GenericTag<FoodFreshness> foodFreshnessTag, int quantity, String expiryDate){
+    public static Item getInstance(String name, GenericTag<FoodGroup> foodGroupTag, GenericTag<FoodFreshness> foodFreshnessTag, int quantity, String expiryDate){
         Date date = parseDate(expiryDate);
-        return Item.getInstance(name, foodGroupTags, foodFreshnessTag, quantity, date);
+        return Item.getInstance(name, foodGroupTag, foodFreshnessTag, quantity, date);
     }
 
     /**
      * Factory method to create an Item instance with food groups and freshness defined by enums.
      *
      * @param name The item's name.
-     * @param foodGroups A set of FoodGroup enums.
+     * @param foodGroup A set of FoodGroup enums.
      * @param foodFreshness The FoodFreshness enum value.
      * @param quantity The quantity of the item.
      * @param expiryDate The item's expiry date.
      * @return A new Item instance.
      */
-    public static Item getInstance(String name, Set<FoodGroup> foodGroups, FoodFreshness foodFreshness, int quantity, Date expiryDate) {
+    public static Item getInstance(String name, FoodGroup foodGroup, FoodFreshness foodFreshness, int quantity, Date expiryDate) {
         Item item = Item.getInstance(name, quantity, expiryDate);
-        item.setFoodGroupTagsEnum(foodGroups);
+        item.setFoodGroupTag(foodGroup);
         item.setFoodFreshnessTag(foodFreshness);
         return item;
     }
@@ -86,15 +86,15 @@ public class Item implements Comparable<Item>{
      * Overloaded factory method to create an Item instance with food groups and freshness defined by enums and a string expiry date.
      *
      * @param name The item's name.
-     * @param foodGroups A set of FoodGroup enums.
+     * @param foodGroup A set of FoodGroup enums.
      * @param foodFreshness The FoodFreshness enum value.
      * @param quantity The quantity of the item.
      * @param expiryDate A string representing the item's expiry date in "dd-MMMM-yyyy" format.
      * @return A new Item instance.
      */
-    public static Item getInstance(String name, Set<FoodGroup> foodGroups, FoodFreshness foodFreshness, int quantity, String expiryDate) {
+    public static Item getInstance(String name, FoodGroup foodGroup, FoodFreshness foodFreshness, int quantity, String expiryDate) {
         Date date = parseDate(expiryDate);
-        return Item.getInstance(name, foodGroups, foodFreshness, quantity, date);
+        return Item.getInstance(name, foodGroup, foodFreshness, quantity, date);
     }
 
     /**
@@ -155,7 +155,7 @@ public class Item implements Comparable<Item>{
      * @return A new Item instance with the same properties as the item parameter.
      */
     public static Item getInstance(Item item){
-        return Item.getInstance(item.getName(), item.getFoodGroupTags(), item.getFoodFreshnessTag(), item.getQuantity(), item.getExpiryDate());
+        return Item.getInstance(item.getName(), item.getFoodGroupTag(), item.getFoodFreshnessTag(), item.getQuantity(), item.getExpiryDate());
     }
 
     // Helper method to parse date strings
@@ -187,12 +187,12 @@ public class Item implements Comparable<Item>{
     }
 
     /**
-     * Gets the food freshness tag.
+     * Gets the food group tag.
      *
-     * @return The food freshness tag if it exists, or null otherwise.
+     * @return The food group tag if it exists, or null otherwise.
      */
     public GenericTag<FoodGroup> getFoodGroupTag() {
-        // Directly return null if foodFreshnessTag is null, avoiding NullPointerException
+        // Directly return null if foodGroupTag is null, avoiding NullPointerException
         if (this.foodGroupTag == null) {
             return null;
         }
@@ -201,23 +201,22 @@ public class Item implements Comparable<Item>{
     }
 
     /**
-     * Sets the food freshness tag from a GenericTag<FoodFreshness>.
+     * Sets the food group tag from a GenericTag<FoodGroup>.
      *
-     * @param tag The new food freshness tag.
+     * @param tag The new food group tag.
      */
     public void setFoodGroupTag(GenericTag<FoodGroup> tag) {
         this.foodGroupTag = new GenericTag<>(tag);
     }
 
     /**
-     * Sets the food freshness tag directly from a FoodFreshness enum.
+     * Sets the food group tag directly from a FoodGroup enum.
      *
-     * @param tag The FoodFreshness enum value.
+     * @param tag The FoodGroup enum value.
      */
-    public void setFoodFreshnessTag(FoodFreshness tag) {
-        this.foodFreshnessTag = new GenericTag<>(tag);
+    public void setFoodGroupTag(FoodGroup tag) {
+        this.foodGroupTag = new GenericTag<>(tag);
     }
-
 
     /**
      * Gets the food freshness tag.
@@ -333,7 +332,7 @@ public class Item implements Comparable<Item>{
     public String toString() {
         return "Item{" +
                 "name='" + name + '\'' +
-                ", foodGroupTags=" + foodGroupTags +
+                ", foodGroupTags=" + foodGroupTag +
                 ", foodFreshnessTag=" + foodFreshnessTag +
                 ", quantity=" + quantity +
                 ", expiryDate=" + expiryDate +

--- a/src/domain/logic/Item.java
+++ b/src/domain/logic/Item.java
@@ -206,7 +206,12 @@ public class Item implements Comparable<Item>{
      * @param tag The new food group tag.
      */
     public void setFoodGroupTag(GenericTag<FoodGroup> tag) {
-        this.foodGroupTag = new GenericTag<>(tag);
+        if (tag == null) {
+            this.foodGroupTag =  null;
+        }
+        else{
+            this.foodGroupTag = new GenericTag<>(tag);
+        }
     }
 
     /**
@@ -238,7 +243,12 @@ public class Item implements Comparable<Item>{
      * @param tag The new food freshness tag.
      */
     public void setFoodFreshnessTag(GenericTag<FoodFreshness> tag) {
-        this.foodFreshnessTag = new GenericTag<>(tag);
+        if (tag == null) {
+            this.foodFreshnessTag =  null;
+        }
+        else{
+            this.foodFreshnessTag = new GenericTag<>(tag);
+        }
     }
 
     /**

--- a/src/domain/logic/ItemUtility.java
+++ b/src/domain/logic/ItemUtility.java
@@ -96,32 +96,16 @@ public class ItemUtility {
      * @param column    The column index corresponding to the property to be updated.
      * @return true if the item was successfully updated, false otherwise.
      */
-    public static boolean updateItem(DB data, Container container, int row, String itemName, Object newValue, int column) {
-        Item item = data.getItem(container, itemName);
-
-        if (item == null) {
-            return false; // Item not found
+    public static void updateItem(DB data, Container container, String itemName, Object newValue, int column) {
+        // Assuming column 3 is FoodGroup and column 4 is FoodFreshness
+        if (column == 3 && newValue instanceof FoodGroup) {
+            data.updateItem(container, itemName, (FoodGroup) newValue, null);
+        } else if (column == 4 && newValue instanceof FoodFreshness) {
+            data.updateItem(container, itemName, null, (FoodFreshness) newValue);
         }
-
-        switch (column) {
-            case 3: // Food Group column
-                if (newValue instanceof FoodGroup) {
-                    FoodGroup selectedGroup = (FoodGroup) newValue;
-                    item.setFoodGroupTag(selectedGroup);
-                }
-                break;
-            case 4: // Food Freshness column
-                if (newValue instanceof FoodFreshness) {
-                    FoodFreshness selectedFreshness = (FoodFreshness) newValue;
-                    item.setFoodFreshnessTag(selectedFreshness);
-                }
-                break;
-            default:
-                return false; // Invalid column for update
-        }
-        return true; // Successfully updated
     }
-    
+
+
     /**
      * Retrieves and initializes the rows in ItemsListViews from the database for a specified container.
      * @param data access to the database

--- a/src/domain/logic/ItemUtility.java
+++ b/src/domain/logic/ItemUtility.java
@@ -2,6 +2,9 @@ package domain.logic;
 
 import gui.HomeView;
 import gui.ItemsListView;
+
+import java.text.SimpleDateFormat;
+import java.util.Date;
 import java.util.function.Consumer;
 
 import javax.swing.table.DefaultTableModel;
@@ -113,13 +116,18 @@ public class ItemUtility {
      * @param tableModel the table object to initialize the rows for
      */
     public static void initItems(DB data, Container c, DefaultTableModel tableModel) {
-
     	List<Item> items = data.retrieveItems(c);
     	tableModel.setRowCount(0);
     	for (Item item : items) {
     		tableModel.addRow(
-    				new Object[] { item.getName(), item.getQuantity(), item.getExpiryDate().toString(), item.getFoodGroupTag(), item.getFoodFreshnessTag() });
+    				new Object[] { item.getName(), item.getQuantity(), dateFormat(item.getExpiryDate()), item.getFoodGroupTag(), item.getFoodFreshnessTag() });
     	}
+    }
+
+    public static String dateFormat(Date expiryDate){
+        SimpleDateFormat formatter = new SimpleDateFormat("yyyy-MM-dd");
+        String format = formatter.format(expiryDate);
+        return format;
     }
 
 }

--- a/src/domain/logic/ItemUtility.java
+++ b/src/domain/logic/ItemUtility.java
@@ -107,8 +107,7 @@ public class ItemUtility {
             case 3: // Food Group column
                 if (newValue instanceof FoodGroup) {
                     FoodGroup selectedGroup = (FoodGroup) newValue;
-                    Set<FoodGroup> foodGroupSet = EnumSet.of(selectedGroup);
-                    item.setFoodGroupTagsEnum(foodGroupSet);
+                    item.setFoodGroupTag(selectedGroup);
                 }
                 break;
             case 4: // Food Freshness column

--- a/src/domain/logic/ItemUtility.java
+++ b/src/domain/logic/ItemUtility.java
@@ -134,7 +134,7 @@ public class ItemUtility {
     	tableModel.setRowCount(0);
     	for (Item item : items) {
     		tableModel.addRow(
-    				new Object[] { item.getName(), item.getQuantity(), item.getExpiryDate().toString(), null, null });
+    				new Object[] { item.getName(), item.getQuantity(), item.getExpiryDate().toString(), item.getFoodGroupTag(), item.getFoodFreshnessTag() });
     	}
     }
 

--- a/src/gui/EnumComboBoxEditor.java
+++ b/src/gui/EnumComboBoxEditor.java
@@ -1,0 +1,27 @@
+package gui;
+
+import domain.logic.Tag;
+
+import javax.swing.*;
+import java.util.HashMap;
+import java.util.Map;
+
+public class EnumComboBoxEditor extends DefaultCellEditor {
+    private Map<String, Object> displayNameToEnumMap = new HashMap<>();
+
+    public <E extends Enum<E> & Tag> EnumComboBoxEditor(E[] values) {
+        super(new JComboBox<>());
+        JComboBox<String> comboBox = (JComboBox<String>) editorComponent;
+        for (E value : values) {
+            String displayName = value.getDisplayName();
+            comboBox.addItem(displayName);
+            displayNameToEnumMap.put(displayName, value);
+        }
+    }
+
+    @Override
+    public Object getCellEditorValue() {
+        String displayName = (String) super.getCellEditorValue();
+        return displayNameToEnumMap.get(displayName);
+    }
+}

--- a/src/gui/ItemsListView.java
+++ b/src/gui/ItemsListView.java
@@ -1,16 +1,40 @@
 package gui;
 
-import java.awt.BorderLayout;
+import java.awt.*;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 
 import javax.swing.*;
 import javax.swing.event.TableModelEvent;
+import javax.swing.table.DefaultTableCellRenderer;
 import javax.swing.table.DefaultTableModel;
 import javax.swing.table.TableModel;
 
 import database.DB;
 import domain.logic.*;
+import domain.logic.Container;
+class EnumComboBoxEditor extends DefaultCellEditor {
+	private Map<String, Object> displayNameToEnumMap = new HashMap<>();
+
+	public <E extends Enum<E> & Tag> EnumComboBoxEditor(E[] values) {
+		super(new JComboBox<>());
+		JComboBox<String> comboBox = (JComboBox<String>) editorComponent;
+		for (E value : values) {
+			String displayName = value.getDisplayName();
+			comboBox.addItem(displayName);
+			displayNameToEnumMap.put(displayName, value);
+		}
+	}
+
+	@Override
+	public Object getCellEditorValue() {
+		String displayName = (String) super.getCellEditorValue();
+		return displayNameToEnumMap.get(displayName);
+	}
+}
+
 
 /**
  * Represents a panel that displays a list of items within a container.
@@ -91,8 +115,9 @@ public class ItemsListView extends JPanel {
 		JComboBox<FoodFreshness> foodFreshnessComboBox = new JComboBox<>(FoodFreshness.values());
 
 		// Set up the food group and food freshness columns with JComboBoxes
-		table.getColumnModel().getColumn(3).setCellEditor(new DefaultCellEditor(foodGroupComboBox));
-		table.getColumnModel().getColumn(4).setCellEditor(new DefaultCellEditor(foodFreshnessComboBox));
+		table.getColumnModel().getColumn(3).setCellEditor(new EnumComboBoxEditor(FoodGroup.values()));
+		table.getColumnModel().getColumn(4).setCellEditor(new EnumComboBoxEditor(FoodFreshness.values()));
+
 
 		add(new JScrollPane(table), BorderLayout.CENTER);
 		
@@ -137,13 +162,8 @@ public class ItemsListView extends JPanel {
 		String itemName = (String) table.getModel().getValueAt(row, 0);
 		Object newValue = table.getModel().getValueAt(row, column);
 
-		boolean updateSuccess = ItemUtility.updateItem(data, container, row, itemName, newValue, column);
-
-		if (updateSuccess) {
-			JOptionPane.showMessageDialog(this, "Item updated successfully.", "Update", JOptionPane.INFORMATION_MESSAGE);
-		} else {
-			JOptionPane.showMessageDialog(this, "Error updating item. Please check the values.", "Error", JOptionPane.ERROR_MESSAGE);
-		}
+		// Call the new ItemUtility update method
+		ItemUtility.updateItem(data, container, itemName, newValue, column);
 	}
 
 }

--- a/src/gui/ItemsListView.java
+++ b/src/gui/ItemsListView.java
@@ -110,11 +110,7 @@ public class ItemsListView extends JPanel {
 			}
 		});
 
-		// Populate JComboBoxes with enum values
-		JComboBox<FoodGroup> foodGroupComboBox = new JComboBox<>(FoodGroup.values());
-		JComboBox<FoodFreshness> foodFreshnessComboBox = new JComboBox<>(FoodFreshness.values());
-
-		// Set up the food group and food freshness columns with JComboBoxes
+		// Set up the food group and food freshness columns with EnumComboBoxEditor
 		table.getColumnModel().getColumn(3).setCellEditor(new EnumComboBoxEditor(FoodGroup.values()));
 		table.getColumnModel().getColumn(4).setCellEditor(new EnumComboBoxEditor(FoodFreshness.values()));
 

--- a/src/gui/ItemsListView.java
+++ b/src/gui/ItemsListView.java
@@ -15,26 +15,6 @@ import javax.swing.table.TableModel;
 import database.DB;
 import domain.logic.*;
 import domain.logic.Container;
-class EnumComboBoxEditor extends DefaultCellEditor {
-	private Map<String, Object> displayNameToEnumMap = new HashMap<>();
-
-	public <E extends Enum<E> & Tag> EnumComboBoxEditor(E[] values) {
-		super(new JComboBox<>());
-		JComboBox<String> comboBox = (JComboBox<String>) editorComponent;
-		for (E value : values) {
-			String displayName = value.getDisplayName();
-			comboBox.addItem(displayName);
-			displayNameToEnumMap.put(displayName, value);
-		}
-	}
-
-	@Override
-	public Object getCellEditorValue() {
-		String displayName = (String) super.getCellEditorValue();
-		return displayNameToEnumMap.get(displayName);
-	}
-}
-
 
 /**
  * Represents a panel that displays a list of items within a container.
@@ -160,6 +140,7 @@ public class ItemsListView extends JPanel {
 
 		// Call the new ItemUtility update method
 		ItemUtility.updateItem(data, container, itemName, newValue, column);
+		ItemUtility.initItems(data, this.container, tableModel);
 	}
 
 }

--- a/src/test/ItemTest.java
+++ b/src/test/ItemTest.java
@@ -25,6 +25,7 @@ class ItemTest {
 	Item item1, item2, itemExpired, itemNearExpiry;
 	Date date1, date2, expiredDate, nearExpiryDate;
 
+	GenericTag<FoodGroup> grain, diary, fruit, veg;
 	@BeforeEach
 	void init() throws ParseException {
 		date1 = sdf.parse("5-May-2024");
@@ -32,18 +33,19 @@ class ItemTest {
 		expiredDate = sdf.parse("1-January-2023");
 		nearExpiryDate = sdf.parse("26-February-2024");
 
-		Set<GenericTag<FoodGroup>> grain = new HashSet<>();
-		grain.add(new GenericTag<>(FoodGroup.GRAIN));
-		Set<GenericTag<FoodGroup>> fruit = new HashSet<>();
-		fruit.add(new GenericTag<>(FoodGroup.FRUIT));
+		GenericTag<FoodGroup> grain = new GenericTag<>(FoodGroup.GRAIN);
+		GenericTag<FoodGroup> dairy = new GenericTag<>(FoodGroup.DAIRY);
+		GenericTag<FoodGroup> fruit = new GenericTag<>(FoodGroup.FRUIT);
+		GenericTag<FoodGroup> veg = new GenericTag<>(FoodGroup.VEGETABLE);
+
 		GenericTag<FoodFreshness> fresh = new GenericTag<>(FoodFreshness.FRESH);
 		GenericTag<FoodFreshness> expired = new GenericTag<>(FoodFreshness.EXPIRED);
 		GenericTag<FoodFreshness> nearExpiry = new GenericTag<>(FoodFreshness.NEAR_EXPIRY);
 
 		item1 = Item.getInstance("Bread", grain, fresh, 3, date1);
 		item2 = Item.getInstance("Apple", fruit, expired, 2, date2);
-		itemExpired = Item.getInstance("Expired Milk", new HashSet<>(), expired, 1, expiredDate);
-		itemNearExpiry = Item.getInstance("Chicken salad", new HashSet<>(), nearExpiry, 1, nearExpiryDate);
+		itemExpired = Item.getInstance("Expired Milk", dairy, expired, 1, expiredDate);
+		itemNearExpiry = Item.getInstance("Chicken salad", veg, nearExpiry, 1, nearExpiryDate);
 	}
 
 	@Test
@@ -55,7 +57,7 @@ class ItemTest {
 
 	@Test
 	void testEqualityAndHashCode() {
-		Item item1Copy = Item.getInstance("Bread", new HashSet<>(), new GenericTag<>(FoodFreshness.FRESH), 3, date1);
+		Item item1Copy = Item.getInstance("Bread", new GenericTag<FoodGroup>(FoodGroup.GRAIN), new GenericTag<>(FoodFreshness.FRESH), 3, date1);
 		assertEquals(item1, item1Copy);
 		assertEquals(item1.hashCode(), item1Copy.hashCode());
 	}
@@ -84,26 +86,24 @@ class ItemTest {
 
 	@Test
 	void testInvalidDateFormat() {
-		assertThrows(RuntimeException.class, () -> Item.getInstance("Bad Date Item", new HashSet<>(),
+		assertThrows(RuntimeException.class, () -> Item.getInstance("Bad Date Item", null,
 				new GenericTag<>(FoodFreshness.FRESH), 1, "31-02-2024"));
 	}
 
 	@Test
 	void testToString() throws ParseException {
-		HashSet<GenericTag<FoodGroup>> foodGroupTags = new HashSet<>();
-		foodGroupTags.add(new GenericTag<>(FoodGroup.DAIRY));
 		Date date = new SimpleDateFormat("dd-MMMM-yyyy").parse("09-january-2024");
 
-		Item item = Item.getInstance("Test Item", foodGroupTags, new GenericTag<>(FoodFreshness.FRESH), 1, date);
-		String expected = "Item{name='Test Item', foodGroupTags=[dairy], foodFreshnessTag=fresh, quantity=1, expiryDate=Tue Jan 09 00:00:00 EST 2024}";
+		Item item = Item.getInstance("Test Item", new GenericTag<>(FoodGroup.DAIRY), new GenericTag<>(FoodFreshness.FRESH), 1, date);
+		String expected = "Item{name='Test Item', foodGroupTags=Dairy, foodFreshnessTag=Fresh, quantity=1, expiryDate=Tue Jan 09 00:00:00 EST 2024}";
 		assertEquals(expected, item.toString(), "toString does not format item as expected.");
 	}
 
 	@Test
 	void testEdgeCaseDateLeapYear() throws ParseException {
 		Date leapYearDate = new SimpleDateFormat("dd-MMMM-yyyy").parse("29-February-2024");
-		HashSet<GenericTag<FoodGroup>> foodGroupTags = new HashSet<>();
-		Item leapYearItem = Item.getInstance("Leap Year Item", foodGroupTags, new GenericTag<>(FoodFreshness.FRESH), 1,
+
+		Item leapYearItem = Item.getInstance("Leap Year Item", new GenericTag<FoodGroup>(FoodGroup.DAIRY), new GenericTag<>(FoodFreshness.FRESH), 1,
 				leapYearDate);
 		assertEquals(leapYearDate, leapYearItem.getExpiryDate(), "Leap year date is not set correctly.");
 	}


### PR DESCRIPTION
- Changed FoodFreshness and FoodGroup enum values to be the same in the database
- Added updateItem method to update tags in database
- Replaced FoodGroupTags, the set of GenericTag<FoodGroup>,  to only FoodGroupTag
- JTable expire date format displays yyyy-MM-dd, same as database Date format
